### PR TITLE
bump versions of deps to avoid breakage

### DIFF
--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -48,14 +48,14 @@ Library
     time == 1.4.*,
     random >= 1.0 && < 1.1,
     containers >= 0.2 && < 0.6,
-    mtl == 2.1.*,
+    mtl >= 2.1 && < 3,
     filepath >= 1.1 && < 1.4,
     directory >= 1.0 && < 1.3,
-    fgl >= 5.4 && < 5.5,
+    fgl >= 5.4 && < 5.6,
     template-haskell,
     yaml-light >= 0.1 && < 0.2,
     bytestring >= 0.9 && < 1.0,
-    text == 0.11.*,
+    text >= 0.11 && < 1.2,
     configurator == 0.2.*
 
   Hs-Source-Dirs:    src
@@ -81,7 +81,7 @@ Executable dbmigrations-tests
     HDBC-postgresql,
     HDBC-sqlite3,
     HUnit >= 1.2 && < 1.3,
-    process == 1.1.*
+    process >= 1.1
 
   if impl(ghc >= 6.12.0)
     ghc-options: -threaded -Wall -fwarn-tabs -funbox-strict-fields


### PR DESCRIPTION
Make things work on ghc 7.8 with modern deps. : )
