### PR TITLE
Don't require testing libraries when not testing

### DIFF
--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -77,11 +77,14 @@ Library
           Moo.Core
 
 Executable dbmigrations-tests
-  Build-Depends:
-    HDBC-postgresql,
-    HDBC-sqlite3,
-    HUnit >= 1.2 && < 1.3,
-    process >= 1.1
+  if flag(testing)
+    Build-Depends:
+      HDBC-postgresql,
+      HDBC-sqlite3,
+      HUnit >= 1.2 && < 1.3,
+      process >= 1.1
+  else
+    Buildable:     False
 
   if impl(ghc >= 6.12.0)
     ghc-options: -threaded -Wall -fwarn-tabs -funbox-strict-fields
@@ -89,8 +92,6 @@ Executable dbmigrations-tests
   else
     ghc-options: -threaded -Wall -fwarn-tabs -funbox-strict-fields
 
-  if !flag(testing)
-    Buildable:     False
 
   Hs-Source-Dirs:  src,test
   Main-is:         TestDriver.hs


### PR DESCRIPTION
Place the `build-depends` portion of the dbmigrations-tests executable underneath a check for the `testing` flag, causing cabal to ignore those dependencies when it is `False`.
