### PR TITLE
Add test for the new MySQL backend

### DIFF
--- a/test/BackendTest.hs
+++ b/test/BackendTest.hs
@@ -1,15 +1,58 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module BackendTest where
 
 import Test.HUnit
+import Control.Exception (Handler(..), catches)
 import Control.Monad ( forM_ )
 
-import Database.Schema.Migrations.Backend.HDBC
+import Database.Schema.Migrations.Backend.HDBC (hdbcBackend)
+import Database.Schema.Migrations.Backend.MySQL
 import Database.Schema.Migrations.Migration ( Migration(..), newMigration )
 import Database.Schema.Migrations.Backend ( Backend(..) )
 
-import Database.HDBC ( IConnection(..), catchSql, withTransaction )
+import qualified Database.HDBC as HDBC
+import qualified Database.MySQL.Simple as MySQL
+import qualified Database.MySQL.Base as MySQL
 
-tests :: (IConnection a) => a -> IO ()
+data BackendConnection
+  = forall a. HDBC.IConnection a => HDBCConnection a
+  | MySQLConnection MySQL.Connection
+
+migrationBackend :: BackendConnection -> Backend
+migrationBackend (HDBCConnection c) = hdbcBackend c
+migrationBackend (MySQLConnection c) = mysqlBackend c
+
+commit :: BackendConnection -> IO ()
+commit (HDBCConnection c) = HDBC.commit c
+commit (MySQLConnection c) = MySQL.commit c
+
+getTables :: BackendConnection -> IO [String]
+getTables (HDBCConnection c) = HDBC.getTables c
+getTables (MySQLConnection c) =
+  fmap (map MySQL.fromOnly)
+       (MySQL.query_ c "SHOW TABLES")
+
+catchSql_ :: IO a -> IO a -> IO a
+catchSql_ act handler =
+  act `catches`
+  [Handler (\(_ :: MySQL.FormatError) -> handler)
+  ,Handler (\(_ :: MySQL.QueryError) -> handler)
+  ,Handler (\(_ :: MySQL.MySQLError) -> handler)
+  ,Handler (\(_ :: MySQL.ResultError) -> handler)
+  ,Handler (\(_ :: HDBC.SqlError) -> handler)]
+
+withTransaction
+  :: BackendConnection -> (BackendConnection -> IO a) -> IO a
+withTransaction (HDBCConnection c) transaction =
+  HDBC.withTransaction c
+                       (transaction . HDBCConnection)
+withTransaction (MySQLConnection c) transaction =
+  MySQL.withTransaction c
+                        (transaction (MySQLConnection c))
+tests :: BackendConnection -> IO ()
 tests conn = do
   let acts = [ isBootstrappedFalseTest
              , bootstrapTest
@@ -24,52 +67,52 @@ tests conn = do
                commit conn
                act conn
 
-bootstrapTest :: (IConnection a) => a -> IO ()
+bootstrapTest :: BackendConnection -> IO ()
 bootstrapTest conn = do
-  let backend = hdbcBackend conn
+  let backend = migrationBackend conn
   bs <- getBootstrapMigration backend
   applyMigration backend bs
   assertEqual "installed_migrations table exists" ["installed_migrations"] =<< getTables conn
   assertEqual "successfully bootstrapped" [mId bs] =<< getMigrations backend
 
-isBootstrappedTrueTest :: (IConnection a) => a -> IO ()
+isBootstrappedTrueTest :: BackendConnection -> IO ()
 isBootstrappedTrueTest conn = do
-  result <- isBootstrapped $ hdbcBackend conn
+  result <- isBootstrapped $ migrationBackend conn
   assertBool "Bootstrapped check" result
 
-isBootstrappedFalseTest :: (IConnection a) => a -> IO ()
+isBootstrappedFalseTest :: BackendConnection -> IO ()
 isBootstrappedFalseTest conn = do
-  result <- isBootstrapped $ hdbcBackend conn
+  result <- isBootstrapped $ migrationBackend conn
   assertBool "Bootstrapped check" $ not result
 
 ignoreSqlExceptions :: IO a -> IO (Maybe a)
-ignoreSqlExceptions act = (act >>= return . Just) `catchSql`
-                       (\_ -> return Nothing)
+ignoreSqlExceptions act = (act >>= return . Just) `catchSql_`
+                          (return Nothing)
 
-applyMigrationSuccess :: (IConnection a) => a -> IO ()
+applyMigrationSuccess :: BackendConnection -> IO ()
 applyMigrationSuccess conn = do
-    let backend = hdbcBackend conn
+    let backend = migrationBackend conn
 
     let m1 = (newMigration "validMigration") { mApply = "CREATE TABLE valid1 (a int); CREATE TABLE valid2 (a int);" }
 
     -- Apply the migrations, ignore exceptions
-    withTransaction conn $ \conn' -> applyMigration (hdbcBackend conn') m1
+    withTransaction conn $ \conn' -> applyMigration (migrationBackend conn') m1
 
     -- Check that none of the migrations were installed
     assertEqual "Installed migrations" ["root", "validMigration"] =<< getMigrations backend
     assertEqual "Installed tables" ["installed_migrations", "valid1", "valid2"] =<< getTables conn
 
 -- |Does a failure to apply a migration imply a transaction rollback?
-applyMigrationFailure :: (IConnection a) => a -> IO ()
+applyMigrationFailure :: BackendConnection -> IO ()
 applyMigrationFailure conn = do
-    let backend = hdbcBackend conn
+    let backend = migrationBackend conn
 
     let m1 = (newMigration "second") { mApply = "CREATE TABLE validButTemporary (a int)" }
         m2 = (newMigration "third") { mApply = "INVALID SQL" }
 
     -- Apply the migrations, ignore exceptions
     ignoreSqlExceptions $ withTransaction conn $ \conn' -> do
-        let backend' = hdbcBackend conn'
+        let backend' = migrationBackend conn'
         applyMigration backend' m1
         applyMigration backend' m2
 
@@ -77,9 +120,9 @@ applyMigrationFailure conn = do
     assertEqual "Installed migrations" ["root"] =<< getMigrations backend
     assertEqual "Installed tables" ["installed_migrations"] =<< getTables conn
 
-revertMigrationFailure :: (IConnection a) => a -> IO ()
+revertMigrationFailure :: BackendConnection -> IO ()
 revertMigrationFailure conn = do
-    let backend = hdbcBackend conn
+    let backend = migrationBackend conn
 
     let m1 = (newMigration "second") { mApply = "CREATE TABLE validRMF (a int)"
                                      , mRevert = Just "DROP TABLE validRMF"}
@@ -96,7 +139,7 @@ revertMigrationFailure conn = do
     -- Revert the migrations, ignore exceptions; the revert will fail,
     -- but withTransaction will roll back.
     ignoreSqlExceptions $ withTransaction conn $ \conn' -> do
-        let backend' = hdbcBackend conn'
+        let backend' = migrationBackend conn'
         revertMigration backend' m2
         revertMigration backend' m1
 
@@ -104,9 +147,9 @@ revertMigrationFailure conn = do
     assertEqual "successfully roll back failed revert" installedBeforeRevert
         =<< getMigrations backend
 
-revertMigrationNothing :: (IConnection a) => a -> IO ()
+revertMigrationNothing :: BackendConnection -> IO ()
 revertMigrationNothing conn = do
-    let backend = hdbcBackend conn
+    let backend = migrationBackend conn
 
     let m1 = (newMigration "second") { mApply = "SELECT 1"
                                      , mRevert = Nothing }
@@ -123,10 +166,10 @@ revertMigrationNothing conn = do
     installed <- getMigrations backend
     assertBool "Check that the migration was reverted" $ not $ "second" `elem` installed
 
-revertMigrationJust :: (IConnection a) => a -> IO ()
+revertMigrationJust :: BackendConnection -> IO ()
 revertMigrationJust conn = do
     let name = "revertable"
-        backend = hdbcBackend conn
+        backend = migrationBackend conn
 
     let m1 = (newMigration name) { mApply = "CREATE TABLE the_test_table (a int)"
                                  , mRevert = Just "DROP TABLE the_test_table" }


### PR DESCRIPTION
There is one known failure at the moment:

    ### Failure in: 1:MySQL backend tests
    Installed migrations
    expected: ["root"]
     but got: ["root","second"]

In this test two migrations are applied in the same transaction, the
first containing valid SQL and the second containing invalid SQL. In
PostgreSQL and SQLite, DDL is transactional and so the initial created
table is rolled back within the transaction. However, MySQL does not
support this - DDL statements aren't scoped by transactions. This means
that even though the third migration fails, the previous migrations are
still visible.