### PR TITLE
v2.1.0 -- swapped out yaml package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.1.0
+-----
+
+Private Atlassian fork by hlevsen@atlassian.com for hackathon app:
+
+- Replace outdated yaml-light dependency with yaml package
+
 2.0.0
 -----
 

--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -1,5 +1,5 @@
 Name:                dbmigrations
-Version:             2.0.0
+Version:             2.1.0
 Synopsis:            An implementation of relational database "migrations"
 Description:         A library and program for the creation,
                      management, and installation of schema updates
@@ -79,13 +79,15 @@ Library
     directory >= 1.0,
     fgl >= 5.4,
     template-haskell,
-    yaml-light >= 0.1,
+    yaml,
     bytestring >= 0.9,
     string-conversions >= 0.4,
     text >= 0.11,
     configurator >= 0.2,
     split >= 0.2.2,
-    HUnit >= 1.2
+    HUnit >= 1.2,
+    aeson < 2,
+    unordered-containers
 
   Hs-Source-Dirs:    src
   Exposed-Modules:

--- a/src/Database/Schema/Migrations/Filesystem.hs
+++ b/src/Database/Schema/Migrations/Filesystem.hs
@@ -27,7 +27,9 @@ import Control.Applicative ( (<$>) )
 import Control.Monad ( filterM )
 import Control.Exception ( IOException, Exception(..), throw, catch )
 
-import Data.Yaml.YamlLight
+import Data.Aeson as J (Object, Value(String, Null))
+import Data.HashMap.Strict as M (toList)
+import Data.Yaml
 
 import Database.Schema.Migrations.Migration
     ( Migration(..)
@@ -104,8 +106,8 @@ migrationFromPath path = do
     readMigrationFile = do
       ymlExists <- doesFileExist (addNewMigrationExtension path)
       if ymlExists
-        then parseYamlFile (addNewMigrationExtension path) `catch` (\(e::IOException) -> throwFS $ show e)
-        else parseYamlFile (addMigrationExtension path filenameExtensionTxt) `catch` (\(e::IOException) -> throwFS $ show e)
+        then decodeFileThrow (addNewMigrationExtension path) `catch` (\(e::IOException) -> throwFS $ show e)
+        else decodeFileThrow (addMigrationExtension path filenameExtensionTxt) `catch` (\(e::IOException) -> throwFS $ show e)
 
     process name = do
       yaml <- readMigrationFile
@@ -122,11 +124,12 @@ migrationFromPath path = do
             Just m -> return m
         _ -> throwFS $ "Error in " ++ (show path) ++ ": missing required field(s): " ++ (show missing)
 
-getFields :: YamlLight -> [(Text, Text)]
-getFields (YMap mp) = map toPair $ Map.assocs mp
+getFields :: J.Object -> [(Text, Text)]
+getFields mp = map toPair $ M.toList mp
     where
-      toPair :: (YamlLight, YamlLight) -> (Text, Text)
-      toPair (YStr k, YStr v) = (cs k, cs v)
+      toPair :: (Text, Value) -> (Text, Text)
+      toPair (k, J.String v) = (cs k, cs v)
+      toPair (k, J.Null) = (cs k, cs ("" :: String))
       toPair (k, v) = throwFS $ "Error in YAML input; expected string key and string value, got " ++ (show (k, v))
 getFields _ = throwFS "Error in YAML input; expected mapping"
 


### PR DESCRIPTION
`yaml-light`'s dependency HsSyck would compile for me because of the underlying C code not being C99 compliant. HsSyck hasn't been maintained for 8 years so instead I propose to swap out `dbmigrations` YAML parsing to `yaml`.