### PR TITLE
v2.1.0 -- swapped out yaml package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Replace outdated yaml-light dependency with yaml package
+
 2.0.0
 -----
 

--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -79,13 +79,15 @@ Library
     directory >= 1.0,
     fgl >= 5.4,
     template-haskell,
-    yaml-light >= 0.1,
+    yaml,
     bytestring >= 0.9,
     string-conversions >= 0.4,
     text >= 0.11,
     configurator >= 0.2,
     split >= 0.2.2,
-    HUnit >= 1.2
+    HUnit >= 1.2,
+    aeson < 2,
+    unordered-containers
 
   Hs-Source-Dirs:    src
   Exposed-Modules:
@@ -118,7 +120,7 @@ test-suite dbmigrations-tests
     directory >= 1.0,
     fgl >= 5.4,
     template-haskell,
-    yaml-light >= 0.1,
+    yaml,
     bytestring >= 0.9,
     string-conversions >= 0.4,
     MissingH,

--- a/test/FilesystemParseTest.hs
+++ b/test/FilesystemParseTest.hs
@@ -100,8 +100,7 @@ migrationParsingTestCases = [ ("valid_full", Right valid_full)
                             , ("invalid_syntax"
                               , Left $ "Could not parse migration " ++
                                          (fp "invalid_syntax") ++
-                                         ":user error (syntax error: line 7, " ++
-                                         "column 0)")
+                                         ":InvalidYaml (Just (YamlParseException {yamlProblem = \"could not find expected ':'\", yamlContext = \"while scanning a simple key\", yamlProblemMark = YamlMark {yamlIndex = 130, yamlLine = 6, yamlColumn = 0}}))")
                             , ("invalid_timestamp"
                               , Left $ "Could not parse migration " ++
                                          (fp "invalid_timestamp") ++


### PR DESCRIPTION
`yaml-light`'s dependency HsSyck would compile for me because of the underlying C code not being C99 compliant. HsSyck hasn't been maintained for 8 years so instead I propose to swap out `dbmigrations` YAML parsing to `yaml`.