### PR TITLE
Aeson-2.x compatibility and fix for new Read(UTCTime)

### DIFF
--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -86,7 +86,7 @@ Library
     configurator >= 0.2,
     split >= 0.2.2,
     HUnit >= 1.2,
-    aeson < 2,
+    aeson,
     unordered-containers
 
   Hs-Source-Dirs:    src

--- a/src/Database/Schema/Migrations/Filesystem.hs
+++ b/src/Database/Schema/Migrations/Filesystem.hs
@@ -175,7 +175,7 @@ fieldProcessors = [ ("Created", setTimestamp )
 setTimestamp :: FieldProcessor
 setTimestamp value m = do
   ts <- case readTimestamp value of
-          ((t, ""):_) -> Right t
+          ((t, ""):_) -> return t
           [(t, _)] -> return t
           _ -> fail "expected one valid parse"
   return $ m { mTimestamp = Just ts }

--- a/src/Database/Schema/Migrations/Filesystem.hs
+++ b/src/Database/Schema/Migrations/Filesystem.hs
@@ -175,6 +175,7 @@ fieldProcessors = [ ("Created", setTimestamp )
 setTimestamp :: FieldProcessor
 setTimestamp value m = do
   ts <- case readTimestamp value of
+          ((t, ""):_) -> Right t
           [(t, _)] -> return t
           _ -> fail "expected one valid parse"
   return $ m { mTimestamp = Just ts }


### PR DESCRIPTION
This gets things building and passing with lts-20.05 / GHC-9.2.5

### [Aeson-2.x compatibility](https://github.com/jtdaugherty/dbmigrations/pull/42/commits/88a1a083df012716fe18bea140eb33a592be33dd)

### [Relax UTCTime parser](https://github.com/jtdaugherty/dbmigrations/pull/42/commits/fe3d19b750369135f48a793004c59969a0597e97)

It seems with the newer time package, `reads` is returning more than a
single element tuple,

```
λ> t = "2009-04-15 10:02:06 UTC"
λ> reads @UTCTime t
[(2009-04-15 10:02:06 UTC,""),(2009-04-15 10:02:06 UTC," UTC")]
```

Checking for a first element with no trailing characters gets the tests
passing again.

**Tangential**: there seems to be a lot more manual processing of the
Yaml than I'd expect. Why does a Migration file not just have a clear
record type along with a `FromJSON` and then you just decode it
(letting aeson handle all error reporting)? Is there some scar tissue and/or
context I'm missing?