### PR TITLE
Rewrite Migration parser using conventional FromJSON

### DIFF
--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -86,7 +86,7 @@ Library
     configurator >= 0.2,
     split >= 0.2.2,
     HUnit >= 1.2,
-    aeson < 2,
+    aeson,
     unordered-containers
 
   Hs-Source-Dirs:    src

--- a/src/Database/Schema/Migrations/Filesystem.hs
+++ b/src/Database/Schema/Migrations/Filesystem.hs
@@ -159,8 +159,8 @@ utcTimeYamlFormat :: String
 utcTimeYamlFormat = "%F %T UTC"
 
 newtype DependsYaml = DependsYaml
-  { unDependsYaml :: [Text]
-  }
+    { unDependsYaml :: [Text]
+    }
 
 instance FromJSON DependsYaml where
     parseJSON = \case

--- a/src/Database/Schema/Migrations/Filesystem.hs
+++ b/src/Database/Schema/Migrations/Filesystem.hs
@@ -113,7 +113,7 @@ data MigrationYaml = MigrationYaml
     , myDescription :: Maybe Text
     , myApply :: Text
     , myRevert :: Maybe Text
-    , myDepends :: Text
+    , myDepends :: Maybe Text
     -- ^ White-space separated names
     }
     deriving Generic
@@ -139,7 +139,7 @@ migrationYamlToMigration theId my = Migration
     , mDesc = myDescription my
     , mApply = myApply my
     , mRevert = myRevert my
-    , mDeps = T.words $ myDepends my
+    , mDeps = maybe [] T.words $ myDepends my
     }
 
 newtype UTCTimeYaml = UTCTimeYaml

--- a/src/Database/Schema/Migrations/Filesystem.hs
+++ b/src/Database/Schema/Migrations/Filesystem.hs
@@ -23,13 +23,11 @@ import Data.Time.Clock ( UTCTime )
 import Data.Time ( defaultTimeLocale, formatTime, parseTimeM )
 import qualified Data.Map as Map
 
-import Control.Applicative ( (<$>), (<|>) )
 import Control.Monad ( filterM )
 import Control.Exception ( Exception(..), throw, catch )
 
 import Data.Aeson
 import Data.Aeson.Types (typeMismatch)
-import Data.HashMap.Strict as M (toList)
 import qualified Data.Yaml as Yaml
 import GHC.Generics (Generic)
 


### PR DESCRIPTION
The code as it was was decoding the Yaml as a type-less `Object`, then
digging around manually in the key-values to "parse" it further, to the actual
`Migration` type. This resulted in a brittle situation (relying on `read`) with
poor error messages ("unrecognized field" was used for a lot of distinct
errors). It also required Aeson internals such that we'd need CPP to build
against 1.x and 2.x.

This series of commits moves to a more idiomatic approach of a record type
with a `FromJSON` that is decoded directly. The decoding then handles
required-vs-optional, parsing, etc.

I recommend by-commit review, as the final result is somewhat complex, but
this was due to some landmines encountered along the way, and there may
exist a simpler approach depending on external constraints. Personally, I'd
say it's worth keeping the custom `UTCTime` en/decoder, but I would not
preserve the quirky "`Depends` must be present but can be `Null`" behavior.

At this point, we are behavior-neutral except for the following changes in error
message:

```
### Failure in: 0:Filesystem Parsing:9
test/FilesystemParseTest.hs:116
expected: Left "Could not parse migration /Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_missing_required_fields:Error in \"/Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_missing_required_fields\": missing required field(s): [\"Depends\"]"
 but got: Left "Could not parse migration /Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_missing_required_fields:AesonException \"Error in $: parsing Database.Schema.Migrations.Filesystem.MigrationYaml(MigrationYaml) failed, key \\\"Depends\\\" not found\""

### Failure in: 0:Filesystem Parsing:10
test/FilesystemParseTest.hs:116
expected: Left "Could not parse migration /Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_field_name:Error in \"/Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_field_name\": unrecognized field found"
 but got: Left "Could not parse migration /Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_field_name:AesonException \"Error in $: parsing Database.Schema.Migrations.Filesystem.MigrationYaml(MigrationYaml) failed, unknown fields: [\\\"InvalidField\\\"]\""

### Failure in: 0:Filesystem Parsing:12
test/FilesystemParseTest.hs:116
expected: Left "Could not parse migration /Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_timestamp:Error in \"/Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_timestamp\": unrecognized field found"
 but got: Left "Could not parse migration /Users/patrick/code/pbrisbin/dbmigrations/test/migration_parsing/invalid_timestamp:AesonException \"Error in $.Created: Unable to parse UTCTime\""
```

Some of this is our intended improvements:

- Actually separating the different reasons of `unrecognized field`
- Displaying more keys/values that are the cause of the failure

But they are a bit noisy without any extra polishing. Therefore, if you'd like to
see the messages tweaked in some way, do let me know. Otherwise, I can just
update the test expectations and we'll be green.
