### PR TITLE
Restore parsing of fractional seconds in the `Created` field.

### DIFF
--- a/dbmigrations.cabal
+++ b/dbmigrations.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -30,6 +30,7 @@ extra-source-files:
     tests/migration_parsing/invalid_syntax.txt
     tests/migration_parsing/invalid_timestamp.txt
     tests/migration_parsing/valid_full.txt
+    tests/migration_parsing/valid_full_fractional_ts.txt
     tests/migration_parsing/valid_no_depends.txt
     tests/migration_parsing/valid_no_desc.txt
     tests/migration_parsing/valid_no_revert.txt

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@ version: 3.0.0
 synopsis: An implementation of relational database "migrations"
 description: Please see <https://github.com/haskell-github-trust/dbmigrations#readme>
 author: "Jonathan Daugherty <cygnus@foobox.com>"
-maintainer: "Pat Brisbin <pbrisbin@gmail.com>"
+maintainer: "Pat Brisbin <pbrisbin@gmail.com>, Kris Nuttycombe <kris@nutty.land>"
 category: Database
 github: haskell-github-trust/dbmigrations
 license: BSD3

--- a/tests/FilesystemParseSpec.hs
+++ b/tests/FilesystemParseSpec.hs
@@ -34,6 +34,10 @@ spec = do
     it "fully valid" $ do
       migrationFromFile' "valid_full" `shouldReturn` Right validFull
 
+    it "fully valid with fractional seconds in timestamp" $ do
+      migrationFromFile' "valid_full_fractional_ts"
+        `shouldReturn` Right (validFullFractionalTs {mId = "valid_full_fractional_ts"})
+
     it "comments" $ do
       migrationFromFile' "valid_with_comments"
         `shouldReturn` Right (validFull {mId = "valid_with_comments"})
@@ -154,3 +158,17 @@ ts = read tsStr
 
 tsStr :: String
 tsStr = "2009-04-15 10:02:06 UTC"
+
+validFullFractionalTs :: Migration
+validFullFractionalTs =
+  Migration
+    { mTimestamp = Just tsFractional
+    , mId = "valid_full_fractional_ts"
+    , mDesc = Just "A valid full migration with fractional seconds."
+    , mDeps = ["another_migration"]
+    , mApply = "CREATE TABLE test ( a int );"
+    , mRevert = Just "DROP TABLE test;"
+    }
+
+tsFractional :: UTCTime
+tsFractional = read "2009-04-15 10:02:06.123456 UTC"

--- a/tests/FilesystemSpec.hs
+++ b/tests/FilesystemSpec.hs
@@ -25,6 +25,7 @@ spec = do
                           , "invalid_syntax"
                           , "invalid_timestamp"
                           , "valid_full"
+                          , "valid_full_fractional_ts"
                           , "valid_no_depends"
                           , "valid_no_desc"
                           , "valid_no_revert"

--- a/tests/migration_parsing/valid_full_fractional_ts.txt
+++ b/tests/migration_parsing/valid_full_fractional_ts.txt
@@ -1,0 +1,10 @@
+Description: A valid full migration with fractional seconds.
+Created: 2009-04-15 10:02:06.123456 UTC
+Depends: another_migration
+Apply:
+
+  CREATE TABLE test (
+    a int
+  );
+
+Revert: DROP TABLE test;


### PR DESCRIPTION
The old show/read format always included fractional seconds in the `Created` field; this fixes a bug that was introduced in 966792329e8e0f68dfc45e0a45c474a2a20222f3 This commit restored parsing fractional seconds, and modified parsing to allow either format.