### PR TITLE
Add Nix flake for build configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .stack-work
+.*.swp
+.cabal-sandbox
+cabal.sandbox.config
+dist
 dist-newstyle
 result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769367530,
+        "narHash": "sha256-EAQT/bLs9vVOat0nWLu427OAmCGwc7QC/e1XFpdtWzI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7ce475e6bf95e7c66c6c980b959a0445d7b9abd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Relational database migrations modeled as a directed acyclic graph";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: let
+    pkg-name = "dbmigrations"; 
+    haskell-overlay = pkgs: hfinal: hprev: let
+      dontCheck = pkg: pkgs.haskell.lib.dontCheck pkg;
+    in {
+      ${pkg-name} = dontCheck (hfinal.callCabal2nixWithOptions pkg-name ./. "-f sqlite -f postgresql" {});
+    };
+
+    overlay = final: prev: {
+      haskellPackages = prev.haskellPackages.extend (haskell-overlay final);
+      dbm-postgresql = "${final.haskellPackages.dbmigrations}/bin/dbm-postgresql";
+      dbm-sqlite = "${final.haskellPackages.dbmigrations}/bin/dbm-sqlite";
+    };
+  in
+    {
+      overlays = {
+        default = overlay;
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [overlay];
+        };
+
+        hspkgs = pkgs.haskellPackages;
+      in {
+        packages = {
+          ${pkg-name} = hspkgs.${pkg-name};
+          default = self.packages.${system}.${pkg-name};
+        };
+
+        devShells = {
+          default = hspkgs.shellFor {
+            packages = _: [self.packages.${system}.${pkg-name}];
+            buildInputs = [
+              pkgs.cabal-install
+              pkgs.dbm-sqlite
+              hspkgs.ormolu
+            ];
+            withHoogle = true;
+            inputsFrom = builtins.attrValues self.packages.${system};
+          };
+        };
+
+        formatter = pkgs.alejandra;
+      }
+    );
+}


### PR DESCRIPTION
This makes it easy for `nix` users to take advantage of recent updates to the project.

This builds atop #48, and should retarget to `main` once that PR merges.